### PR TITLE
ec2machine: do not attempt to use a private dns address

### DIFF
--- a/ec2system/ec2machine.go
+++ b/ec2system/ec2machine.go
@@ -611,8 +611,9 @@ func getAddress(instance *ec2.Instance) string {
 	for _, ptr := range []*string{
 		instance.PublicDnsName,
 		instance.PublicIpAddress,
-		instance.PrivateDnsName,
 		instance.PrivateIpAddress,
+		// NOTE: do not return a private DNS name since in it is not guaranteed to
+		//       be resolvable externally.
 	} {
 		if val := aws.StringValue(ptr); len(val) > 0 {
 			return val


### PR DESCRIPTION
Private dns names are not always resolvable outside of AWS, this PR avoids using them and instead uses their IP address directly. Public dns and ip address are still preferred over the private ip.