### PR TITLE
separate binary upload from exec

### DIFF
--- a/cmd/ec2boot/install.bash
+++ b/cmd/ec2boot/install.bash
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-VERSION=ec2boot0.3
+VERSION=ec2boot0.4
 
 GOOS=linux GOARCH=amd64 go build -o /tmp/$VERSION .
 cloudkey ti-apps/admin aws s3 cp --acl public-read /tmp/$VERSION s3://grail-public-bin/linux/amd64/$VERSION

--- a/ec2system/ec2machine.go
+++ b/ec2system/ec2machine.go
@@ -182,7 +182,7 @@ type System struct {
 	// contains the ec2machine implementation and runs bigmachine's
 	// supervisor service. By default the following binary is used:
 	//
-	//	https://grail-public-bin.s3-us-west-2.amazonaws.com/linux/amd64/ec2boot0.3
+	//	https://grail-public-bin.s3-us-west-2.amazonaws.com/linux/amd64/ec2boot0.4
 	//
 	// The binary is fetched by a vanilla curl(1) invocation, and thus needs
 	// to be publicly available.
@@ -268,7 +268,7 @@ func (s *System) Init(b *bigmachine.B) error {
 		s.Diskspace = 200
 	}
 	if s.Binary == "" {
-		s.Binary = "https://grail-public-bin.s3-us-west-2.amazonaws.com/linux/amd64/ec2boot0.3"
+		s.Binary = "https://grail-public-bin.s3-us-west-2.amazonaws.com/linux/amd64/ec2boot0.4"
 	}
 	var ok bool
 	s.config, ok = instanceTypes[s.InstanceType]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.25.13
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/google/pprof v0.0.0-20190930153522-6ce02741cba3
-	github.com/grailbio/base v0.0.5
+	github.com/grailbio/base v0.0.6
 	github.com/grailbio/testutil v0.0.3
 	github.com/shirou/gopsutil v2.19.9+incompatible
 	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc

--- a/go.sum
+++ b/go.sum
@@ -3,7 +3,6 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
-cloud.google.com/go v0.44.3/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
@@ -14,6 +13,7 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/StackExchange/wmi v0.0.0-20170410192909-ea383cf3ba6e/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
@@ -21,10 +21,9 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/aws/aws-sdk-go v1.23.14/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.22/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.25.8 h1:n7I+HUUXjun2CsX7JK+1hpRIkZrlKhd3nayeb+Xmavs=
-github.com/aws/aws-sdk-go v1.25.8/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.10 h1:3epJfNmP6xWkOpLOdhIIj07+9UAJwvbzq8bBzyPigI4=
 github.com/aws/aws-sdk-go v1.25.10/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.25.13 h1:qc1PpYdVQXI4eH5Ou25LD3Mb68HAY+AUn7yG4cWlqj8=
 github.com/aws/aws-sdk-go v1.25.13/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/biogo/store v0.0.0-20190426020002-884f370e325d/go.mod h1:Iev9Q3MErcn+w3UOJD/DkEzllvugfdx7bGcMOFhvr/4=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -80,16 +79,8 @@ github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvK
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grailbio/base v0.0.1 h1:AUaPetRbOP7ytAVJAQjg74DgIrgwz29GxbyckQGrnVk=
 github.com/grailbio/base v0.0.1/go.mod h1:wVM2Cq2/HT0rt6WYGQhXJ3CCLkNnGjeAAOPHCZ2IsN0=
-github.com/grailbio/base v0.0.2-0.20191009160242-cc2f64b45a73 h1:afFOVfFvSdbodLBMSA6if3UTxa2JqfkCAs3WiZyEebM=
-github.com/grailbio/base v0.0.2-0.20191009160242-cc2f64b45a73/go.mod h1:eZYf8CS0lMgIx6ThepShqNhCalIvdLo2qThvYdB5488=
-github.com/grailbio/base v0.0.2-0.20191010230300-5f64930c0f7d h1:Cs3yXvj4zSUd3a5u4AFYPi/kDX4jAx3WdwyywW4CoYQ=
-github.com/grailbio/base v0.0.2-0.20191010230300-5f64930c0f7d/go.mod h1:eZYf8CS0lMgIx6ThepShqNhCalIvdLo2qThvYdB5488=
-github.com/grailbio/base v0.0.3 h1:6tfaNuuRtvjYiZyUjRPl9ts9BQSPxm5+MhAKDYD/1go=
-github.com/grailbio/base v0.0.3/go.mod h1:5jH7c17b/2q/bkCPjji0FhGLnV70Mr/MNgVyQmBA9bk=
-github.com/grailbio/base v0.0.4 h1:ZaFDtFlGbdiIfwfdYkCuEJ3w/3ognQUqF7+Lp4KQsDc=
-github.com/grailbio/base v0.0.4/go.mod h1:OFVz7zmqb1D+Jbew0B4DCIpl4ozzVFxf+JKQZBBIQzE=
-github.com/grailbio/base v0.0.5 h1:9LoafGwmMR4QPEOZ5Kz0posu/pbGhDleT7Owqj8l7Yg=
-github.com/grailbio/base v0.0.5/go.mod h1:OFVz7zmqb1D+Jbew0B4DCIpl4ozzVFxf+JKQZBBIQzE=
+github.com/grailbio/base v0.0.6 h1:Hr1OHe16+sQEf4CytYlTu2bR+Sq5VENKA/sZoDBGo+k=
+github.com/grailbio/base v0.0.6/go.mod h1:OFVz7zmqb1D+Jbew0B4DCIpl4ozzVFxf+JKQZBBIQzE=
 github.com/grailbio/v23/factories/grail v0.0.0-20190904050408-8a555d238e9a h1:kAl1x1ErQgs55bcm/WdoKCPny/kIF7COmC+UGQ9GKcM=
 github.com/grailbio/v23/factories/grail v0.0.0-20190904050408-8a555d238e9a/go.mod h1:2g5HI42KHw+BDBdjLP3zs+WvTHlDK3RoE8crjCl26y4=
 github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=
@@ -108,7 +99,6 @@ github.com/keybase/go-keychain v0.0.0-20190828153431-2390ae572545/go.mod h1:JJNr
 github.com/keybase/go-ps v0.0.0-20161005175911-668c8856d999/go.mod h1:hY+WOq6m2FpbvyrI93sMaypsttvaIL5nhVR92dTMUcQ=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.8.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.8.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.8.6/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -132,6 +122,7 @@ github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMT
 github.com/shirou/gopsutil v2.19.9+incompatible h1:IrPVlK4nfwW10DF7pW+7YJKws9NkgNzWozwwWv9FsgY=
 github.com/shirou/gopsutil v2.19.9+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -244,7 +235,6 @@ google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.10.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
-google.golang.org/api v0.11.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -260,10 +250,8 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
 google.golang.org/genproto v0.0.0-20191007204434-a023cd5227bd/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
-google.golang.org/grpc v1.19.1/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
-google.golang.org/grpc v1.21.4/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/machine.go
+++ b/machine.go
@@ -521,7 +521,8 @@ func (m *Machine) exec(ctx context.Context) error {
 	// at a minimum 100 kB/s upload bandwidth.
 	//
 	// TODO(marius): this needs to be improved. We should probably
-	// base this on measuring progress instead (e.g., by rating the )
+	// base this on measuring progress instead (e.g., by wrapping
+	// the reader).
 	const timeout = 10 * time.Second
 	var info Info
 	if err := m.timeoutCall(ctx, timeout, "Supervisor.Info", struct{}{}, &info); err != nil {
@@ -538,7 +539,7 @@ func (m *Machine) exec(ctx context.Context) error {
 		return err
 	}
 	const floor = 100 << 10 // bps
-	uploadTimeout := time.Duration(binInfo.Size/floor) * time.Second
+	uploadTimeout := time.Duration((binInfo.Size+floor-1)/floor) * time.Second
 	log.Debug.Printf("exec: upload timeout: %v", uploadTimeout)
 	if err := m.timeoutCall(ctx, timeout, "Supervisor.Keepalive", uploadTimeout, nil); err != nil {
 		log.Error.Printf("Keepalive %v: %v", m.Addr, err)

--- a/machine.go
+++ b/machine.go
@@ -339,16 +339,10 @@ func (m *Machine) loop(ctx context.Context, system System) {
 				m.setError(err)
 				return
 			}
-			// Give us some extra time now. This keepalive will die anyway
-			// after we exec.
-			keepaliveCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-			if err := m.call(keepaliveCtx, "Supervisor.Keepalive", 10*time.Minute, nil); err != nil {
-				log.Error.Printf("Keepalive %v: %v", m.Addr, err)
-			}
-			cancel()
+
 			// Exec the current binary onto the machine. This will make the
 			// machine unresponsive, because it will not have a chance to reply
-			// to the exec call. We give it some time to recover.
+			// to the exec call.
 			err := m.exec(ctx)
 			// We expect an error since the process is execed before it has a chance
 			// to reply. We check at least that the error comes from the right place
@@ -514,30 +508,51 @@ func (m *Machine) context(ctx context.Context) (mctx context.Context, cancel fun
 	}
 }
 
+// Exec prepares the remote machine for binary replacement, and then
+// calls Supervisor.Exec.
 func (m *Machine) exec(ctx context.Context) error {
 	self, err := fatbin.Self()
 	if err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer cancel()
+
+	// We first get the target GOOS/GOARCH so that we can
+	// compute the total time to allow for uploads, assuming
+	// at a minimum 100 kB/s upload bandwidth.
+	//
+	// TODO(marius): this needs to be improved. We should probably
+	// base this on measuring progress instead (e.g., by rating the )
+	const timeout = 10 * time.Second
 	var info Info
-	if err := m.call(ctx, "Supervisor.Info", struct{}{}, &info); err != nil {
+	if err := m.timeoutCall(ctx, timeout, "Supervisor.Info", struct{}{}, &info); err != nil {
 		return err
 	}
-	// First set the correct environment and arguments.
-	if err := m.call(ctx, "Supervisor.Setenv", m.environ, nil); err != nil {
+	binInfo, ok := self.Stat(info.Goos, info.Goarch)
+	if !ok {
+		return errors.E(errors.Fatal, "no image for ", info.Goos, "/", info.Goarch)
+	}
+	if err := m.timeoutCall(ctx, timeout, "Supervisor.Setenv", m.environ, nil); err != nil {
 		return err
 	}
-	if err := m.call(ctx, "Supervisor.Setargs", os.Args, nil); err != nil {
+	if err := m.timeoutCall(ctx, timeout, "Supervisor.Setargs", os.Args, nil); err != nil {
 		return err
 	}
+	const floor = 100 << 10 // bps
+	uploadTimeout := time.Duration(binInfo.Size/floor) * time.Second
+	log.Debug.Printf("exec: upload timeout: %v", uploadTimeout)
+	if err := m.timeoutCall(ctx, timeout, "Supervisor.Keepalive", uploadTimeout, nil); err != nil {
+		log.Error.Printf("Keepalive %v: %v", m.Addr, err)
+	}
+
 	rc, err := self.Open(info.Goos, info.Goarch)
 	if err != nil {
 		return err
 	}
 	defer rc.Close()
-	return m.call(ctx, "Supervisor.Exec", rc, nil)
+	if err := m.call(ctx, "Supervisor.Setbinary", rc, nil); err != nil {
+		return err
+	}
+	return m.timeoutCall(ctx, timeout, "Supervisor.Exec", struct{}{}, nil)
 }
 
 func (m *Machine) call(ctx context.Context, serviceMethod string, arg, reply interface{}) (err error) {
@@ -558,6 +573,13 @@ func (m *Machine) call(ctx context.Context, serviceMethod string, arg, reply int
 		}()
 	}
 	err = m.client.Call(ctx, m.Addr, serviceMethod, arg, reply)
+	return err
+}
+
+func (m *Machine) timeoutCall(ctx context.Context, timeout time.Duration, serviceMethod string, arg, reply interface{}) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	err := m.call(ctx, serviceMethod, arg, reply)
+	cancel()
 	return err
 }
 

--- a/machine_test.go
+++ b/machine_test.go
@@ -16,8 +16,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grailbio/bigmachine/rpc"
 	"github.com/grailbio/base/errors"
+	"github.com/grailbio/bigmachine/rpc"
 )
 
 var fakeDigest = digester.FromString("fake binary")
@@ -46,7 +46,7 @@ func (s *fakeSupervisor) Setbinary(ctx context.Context, binary io.Reader, _ *str
 	return err
 }
 
-func (s *fakeSupervisor) Getbinary(ctx context.Context, _ struct{}, rc *io.ReadCloser) error {
+func (s *fakeSupervisor) GetBinary(ctx context.Context, _ struct{}, rc *io.ReadCloser) error {
 	if s.Image == nil {
 		return errors.E(errors.Invalid, "no binary set")
 	}

--- a/machine_test.go
+++ b/machine_test.go
@@ -7,7 +7,6 @@ package bigmachine
 import (
 	"bytes"
 	"context"
-	"errors"
 	"io"
 	"io/ioutil"
 	"log"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	"github.com/grailbio/bigmachine/rpc"
+	"github.com/grailbio/base/errors"
 )
 
 var fakeDigest = digester.FromString("fake binary")
@@ -28,6 +28,7 @@ type fakeSupervisor struct {
 	Image         []byte
 	LastKeepalive time.Time
 	Hung          bool
+	Execd         bool
 }
 
 func (s *fakeSupervisor) Setenv(ctx context.Context, env []string, _ *struct{}) error {
@@ -40,10 +41,22 @@ func (s *fakeSupervisor) Setargs(ctx context.Context, args []string, _ *struct{}
 	return nil
 }
 
-func (s *fakeSupervisor) Exec(ctx context.Context, exec io.Reader, _ *struct{}) error {
-	var err error
-	s.Image, err = ioutil.ReadAll(exec)
+func (s *fakeSupervisor) Setbinary(ctx context.Context, binary io.Reader, _ *struct{}) (err error) {
+	s.Image, err = ioutil.ReadAll(binary)
 	return err
+}
+
+func (s *fakeSupervisor) Getbinary(ctx context.Context, _ struct{}, rc *io.ReadCloser) error {
+	if s.Image == nil {
+		return errors.E(errors.Invalid, "no binary set")
+	}
+	*rc = ioutil.NopCloser(bytes.NewReader(s.Image))
+	return nil
+}
+
+func (s *fakeSupervisor) Exec(ctx context.Context, exec io.Reader, _ *struct{}) error {
+	s.Execd = true
+	return nil
 }
 
 func (s *fakeSupervisor) Tail(ctx context.Context, fd int, rc *io.ReadCloser) error {

--- a/supervisor.go
+++ b/supervisor.go
@@ -171,13 +171,13 @@ func (s *Supervisor) Setbinary(ctx context.Context, binary io.Reader, _ *struct{
 	return nil
 }
 
-// Getbinary retrieves the last binary uploaded via Setbinary.
-func (s *Supervisor) Getbinary(ctx context.Context, _ struct{}, rc *io.ReadCloser) error {
+// GetBinary retrieves the last binary uploaded via Setbinary.
+func (s *Supervisor) GetBinary(ctx context.Context, _ struct{}, rc *io.ReadCloser) error {
 	s.mu.Lock()
 	path := s.binaryPath
 	s.mu.Unlock()
 	if path == "" {
-		return errors.E(errors.Invalid, "Supervisor.Getbinary: no binary set")
+		return errors.E(errors.Invalid, "Supervisor.GetBinary: no binary set")
 	}
 	f, err := os.Open(path)
 	*rc = f


### PR DESCRIPTION

This change separates binary upload from binary exec, so that a separate
timeout may be specified in teh case of the former. This allows
Bigmachine-systems to run in more bandwidth constrained scenarios.

This timeout is now computed based on a bandwidth floor of 100 kB/s.
(Arbitrary but reasonable.)

The change also adds a Getbinary method to the supervisor so that we can
distribute binaries among workers instead of re-uploading the binary
every time. (Implementing this is a future change.)

While this change improves the chances of success in bandwidth
constrained setups, using an overall timeout for stall detection is
still suboptimal. Future work includes monitoring upload progress
directly, and failing on stalls.