### PR TITLE
ec2system: change handling of default ec2boot binaries

### DIFF
--- a/ec2system/config.go
+++ b/ec2system/config.go
@@ -11,6 +11,15 @@ import (
 	"github.com/grailbio/base/config"
 )
 
+// Defaults for the ec2boot binary. These are used when the "binary" value is empty.
+// For backwards compatibility (old configs), any binary with the prefix
+// defaultEc2BootPrefix is rewritten to the current version.
+const (
+	defaultEc2BootPrefix  = "https://grail-public-bin.s3-us-west-2.amazonaws.com/linux/amd64/ec2boot"
+	defaultEc2BootVersion = "0.4"
+	defaultEc2Boot        = defaultEc2BootPrefix + defaultEc2BootVersion
+)
+
 func init() {
 	config.Register("bigmachine/ec2system", func(constr *config.Constructor) {
 		var system System
@@ -26,7 +35,7 @@ func init() {
 		diskspace := constr.Int("diskspace", 200, "the amount of (root) disk space to allocate")
 		dataspace := constr.Int("dataspace", 0, "the amount of scratch/data space to allocate")
 		constr.StringVar(&system.Binary, "binary",
-			"https://grail-public-bin.s3-us-west-2.amazonaws.com/linux/amd64/ec2boot0.3",
+			"",
 			"the bootstrap bigmachine binary with which machines are launched")
 		sshkeys := constr.String("sshkey", "", "comma-separated list of ssh keys to be installed")
 		constr.StringVar(&system.Username, "username", "", "user name for tagging purposes")

--- a/ec2system/ec2machine.go
+++ b/ec2system/ec2machine.go
@@ -180,9 +180,8 @@ type System struct {
 	// Binary is the URL to a bootstrap binary to be used when launching
 	// system instances. It should be a minimal bigmachine build that
 	// contains the ec2machine implementation and runs bigmachine's
-	// supervisor service. By default the following binary is used:
-	//
-	//	https://grail-public-bin.s3-us-west-2.amazonaws.com/linux/amd64/ec2boot0.4
+	// supervisor service. If the value of Binary is empty, then the
+	// default ec2boot binary is used.
 	//
 	// The binary is fetched by a vanilla curl(1) invocation, and thus needs
 	// to be publicly available.
@@ -268,7 +267,10 @@ func (s *System) Init(b *bigmachine.B) error {
 		s.Diskspace = 200
 	}
 	if s.Binary == "" {
-		s.Binary = "https://grail-public-bin.s3-us-west-2.amazonaws.com/linux/amd64/ec2boot0.4"
+		s.Binary = defaultEc2Boot
+	} else if s.Binary != defaultEc2Boot && strings.HasPrefix(s.Binary, defaultEc2BootPrefix) {
+		log.Print("ec2boot: using current binary: ", defaultEc2Boot)
+		s.Binary = defaultEc2Boot
 	}
 	var ok bool
 	s.config, ok = instanceTypes[s.InstanceType]


### PR DESCRIPTION

Instead of hardcoding ec2boot in the config (which materializes to,
e.g., $HOME/.bigslice/config), we set the default to an empty string,
and fill in the default binary associated with the current release.

We also rewrite binaries with the  official prefix to match the current
version.