### PR TITLE
ec2system: add URL prefix to prevent address recycling

### DIFF
--- a/cmd/ec2boot/install.bash
+++ b/cmd/ec2boot/install.bash
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-VERSION=ec2boot0.4
+VERSION=ec2boot0.5
 
 GOOS=linux GOARCH=amd64 go build -o /tmp/$VERSION .
 cloudkey ti-apps/admin aws s3 cp --acl public-read /tmp/$VERSION s3://grail-public-bin/linux/amd64/$VERSION

--- a/ec2system/config.go
+++ b/ec2system/config.go
@@ -16,7 +16,7 @@ import (
 // defaultEc2BootPrefix is rewritten to the current version.
 const (
 	defaultEc2BootPrefix  = "https://grail-public-bin.s3-us-west-2.amazonaws.com/linux/amd64/ec2boot"
-	defaultEc2BootVersion = "0.4"
+	defaultEc2BootVersion = "0.5"
 	defaultEc2Boot        = defaultEc2BootPrefix + defaultEc2BootVersion
 )
 

--- a/ec2system/ec2machine.go
+++ b/ec2system/ec2machine.go
@@ -610,7 +610,7 @@ func (s *System) Start(ctx context.Context, count int) ([]*bigmachine.Machine, e
 		}
 		machines[i] = new(bigmachine.Machine)
 		machines[i].Addr = fmt.Sprintf("https://%s/", addr)
-		if useInstanceIDPrefix {
+		if useInstanceIDSuffix {
 			machines[i].Addr += aws.StringValue(instance.InstanceId) + "/"
 		}
 		machines[i].Maxprocs = int(s.config.VCPU)

--- a/ec2system/ec2machine.go
+++ b/ec2system/ec2machine.go
@@ -91,10 +91,10 @@ var (
 	// Used to rate limit EC2 calls.
 	limiter = rate.NewLimiter(rate.Limit(1), 2)
 
-	// useInstanceIDPrefix determines whether machine addresses
+	// useInstanceIDSuffix determines whether machine addresses
 	// assigned by ec2system should include the AWS EC2 instance IDs.
 	// This is exposed as an option here for testing purposes.
-	useInstanceIDPrefix = true
+	useInstanceIDSuffix = true
 )
 
 var immortal = flag.Bool("ec2machineimmortal", false, "make immortal EC2 instances (debugging only)")
@@ -611,7 +611,7 @@ func (s *System) Start(ctx context.Context, count int) ([]*bigmachine.Machine, e
 		machines[i] = new(bigmachine.Machine)
 		machines[i].Addr = fmt.Sprintf("https://%s/", addr)
 		if useInstanceIDPrefix {
-			machines[i].Addr += "/" + aws.StringValue(instance.InstanceId) + "/"
+			machines[i].Addr += aws.StringValue(instance.InstanceId) + "/"
 		}
 		machines[i].Maxprocs = int(s.config.VCPU)
 	}
@@ -898,7 +898,7 @@ func (s *System) ListenAndServe(addr string, handler http.Handler) error {
 	if err != nil {
 		return err
 	}
-	if useInstanceIDPrefix {
+	if useInstanceIDSuffix {
 		sess, err := session.NewSession(s.AWSConfig)
 		if err != nil {
 			log.Error.Printf("session.NewSession: %v", err)

--- a/ec2system/ec2machine_test.go
+++ b/ec2system/ec2machine_test.go
@@ -41,10 +41,10 @@ func TestDiskConfig(t *testing.T) {
 }
 
 func TestMutualHTTPS(t *testing.T) {
-	save := useInstanceIDPrefix
-	useInstanceIDPrefix = false
+	save := useInstanceIDSuffix
+	useInstanceIDSuffix = false
 	defer func() {
-		useInstanceIDPrefix = save
+		useInstanceIDSuffix = save
 	}()
 	// This is a really nasty way of testing what's going on here,
 	// but we do want to test this property end-to-end.

--- a/ec2system/ec2machine_test.go
+++ b/ec2system/ec2machine_test.go
@@ -41,6 +41,11 @@ func TestDiskConfig(t *testing.T) {
 }
 
 func TestMutualHTTPS(t *testing.T) {
+	save := useInstanceIDPrefix
+	useInstanceIDPrefix = false
+	defer func() {
+		useInstanceIDPrefix = save
+	}()
 	// This is a really nasty way of testing what's going on here,
 	// but we do want to test this property end-to-end.
 	mux := new(http.ServeMux)
@@ -69,7 +74,9 @@ func TestMutualHTTPS(t *testing.T) {
 	}
 
 	go func() {
-		sys.ListenAndServe(fmt.Sprintf(":%d", port), mux)
+		if err := sys.ListenAndServe(fmt.Sprintf(":%d", port), mux); err != nil {
+			t.Fatal(err)
+		}
 	}()
 	time.Sleep(time.Second)
 


### PR DESCRIPTION
As outlined in #15, ec2system can currently recycle machine
addresses. This could be bad for downstream systems that depend on
addresses being unique (e.g., Bigslice storing the location of tasks
this way).

This fixes the problem by using the instance id as the URL prefix.
This has several advantages: first, it can be computed independently
in the driver and the worker; second, the URL carries meaningful
information: e.g., the EC2 instance ID is unique and can be used to
look up entries in cloudwatch, etc.