### PR TITLE
Simplify waiting for log propagation

### DIFF
--- a/bigmachine.go
+++ b/bigmachine.go
@@ -384,11 +384,11 @@ func shutdownAllMachines(ctx context.Context, duration time.Duration, machines [
 	ctx, cancel := context.WithTimeout(ctx, duration)
 	defer cancel()
 	var wg sync.WaitGroup
+	wg.Add(len(machines))
 	// Wait for the logs to propagate or for a timeout to occur.
 	for _, m := range machines {
 		// Capture variables for closure below.
 		addr, ch := m.Addr, m.tailDone
-		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			select {

--- a/machine_test.go
+++ b/machine_test.go
@@ -109,7 +109,7 @@ func newTestMachine(t *testing.T, params ...Param) (m *Machine, supervisor *fake
 		keepalivePeriod:     time.Minute,
 		keepaliveTimeout:    2 * time.Minute,
 		keepaliveRpcTimeout: 10 * time.Second,
-		tailDone:            make(chan struct{}, 1),
+		tailDone:            make(chan struct{}),
 	}
 	for _, param := range params {
 		param.applyParam(m)


### PR DESCRIPTION
Simplify waiting for log propagation by:
- using a `sync.WaitGroup` instead of an `errgroup.Group`.  We don't use any of the error propagation or context cancellation features of `errgroup.Group`.
- using an unbuffered channel for `tailDone`.  We only communicate by closing the channel, so buffering is immaterial.  When reading code, no one has to wonder, "why is this buffered?", like I did.

I arrived here because internal linting complained about not checking the error return of `grp.Wait()`, and I decided to simplify rather than explicitly ignoring the error and adding a comment explaining why.