### PR TITLE
Close all connections when resetting clients

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -209,7 +209,7 @@ func (c *Client) Call(ctx context.Context, addr, serviceMethod string, arg, repl
 			*arg = streamReader{resp}
 			return nil
 		}
-		// In all other cases, we close thet body.
+		// In all other cases, we close the body.
 		defer resp.Body.Close()
 		switch {
 		case resp.StatusCode == methodErrorCode:


### PR DESCRIPTION
Close all connections when "resetting" clients. We reset clients by disposing of the clients and backing transports on error. Transports are only garbage collected when all connections, including idle connections, are closed. The existing code was not handling the case in which successful requests followed failed requests. We would eject the client from our cache, but subsequent successful requests would not close the remaining transport connections. The end result is that client resets could cause transport leaks. This is problematic for very long-running computations.

Change this to close idle connections on clients/transports that have been reset.