### PR TITLE
Use temporary files to buffer profiles

### DIFF
--- a/internal/filebuf/filebuf.go
+++ b/internal/filebuf/filebuf.go
@@ -1,0 +1,61 @@
+package filebuf
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/grailbio/base/errors"
+)
+
+// FileBuf is a file-backed buffer that buffers the entire contents of reader.
+// This is useful for fully buffering a network read with low memory overhead.
+type FileBuf struct {
+	// file is the temporary file that backs this buffer.
+	file *os.File
+}
+
+// New creates a new file-backed buffer containing the entire contents of r. If
+// there is an error reading from r, an error is returned. If r is an io.Closer,
+// r is closed once it is fully read.
+func New(r io.Reader) (b *FileBuf, err error) {
+	if rc, ok := r.(io.Closer); ok {
+		defer rc.Close()
+	}
+	file, err := ioutil.TempFile("", "bigslice-filebuf-")
+	if err != nil {
+		return nil, errors.E("error opening temp file for filebuf", err)
+	}
+	defer func() {
+		if err != nil {
+			// We created the temporary file but had some other downstream
+			// error, so we clean up the file now instead of in Close.
+			os.Remove(file.Name())
+		}
+	}()
+	_, err = io.Copy(file, r)
+	if err != nil {
+		return nil, errors.E("error reading into filebuf", err)
+	}
+	_, err = file.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, errors.E("error seeking in filebuf", err)
+	}
+	return &FileBuf{file: file}, nil
+}
+
+// Read implements (io.Reader).Read.
+func (b *FileBuf) Read(p []byte) (int, error) {
+	return b.file.Read(p)
+}
+
+// Close implements (io.Closer).Close.
+func (b *FileBuf) Close() error {
+	if b.file == nil {
+		return nil
+	}
+	defer os.Remove(b.file.Name())
+	err := b.file.Close()
+	b.file = nil
+	return err
+}

--- a/internal/filebuf/filebuf.go
+++ b/internal/filebuf/filebuf.go
@@ -22,7 +22,7 @@ func New(r io.Reader) (b *FileBuf, err error) {
 	if rc, ok := r.(io.Closer); ok {
 		defer rc.Close()
 	}
-	file, err := ioutil.TempFile("", "bigslice-filebuf-")
+	file, err := ioutil.TempFile("", "bigmachine-filebuf-")
 	if err != nil {
 		return nil, errors.E("error opening temp file for filebuf", err)
 	}

--- a/internal/filebuf/filebuf_test.go
+++ b/internal/filebuf/filebuf_test.go
@@ -1,0 +1,55 @@
+package filebuf
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"testing"
+
+	"github.com/grailbio/testutil/expect"
+)
+
+type fakeReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (r *fakeReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read(p []byte) (int, error) {
+	return 0, r.err
+}
+
+// TestFileBuf verifies that we can create, read from, and close a FileBuf.
+func TestFileBuf(t *testing.T) {
+	in := make([]byte, 1<<20)
+	rand.Read(in)
+	rc := &fakeReadCloser{
+		Reader: bytes.NewReader(append([]byte{}, in...)),
+	}
+	b, err := New(rc)
+	expect.NoError(t, err)
+	out, err := ioutil.ReadAll(b)
+	expect.NoError(t, err)
+	expect.EQ(t, out, in)
+	err = b.Close()
+	expect.NoError(t, err)
+	expect.True(t, rc.closed)
+}
+
+// TestFileBufReadError verifies that an error reading from the underlying
+// reader is propagated.
+func TestFileBufReadError(t *testing.T) {
+	r := errorReader{fmt.Errorf("test error")}
+	_, err := New(r)
+	expect.HasSubstr(t, err.Error(), "test error")
+}

--- a/profile.go
+++ b/profile.go
@@ -168,8 +168,9 @@ func (p profiler) Marshal(ctx context.Context, w io.Writer) (err error) {
 	}
 	defer func() {
 		// We generally close the profile buffers as we are done using them to
-		// free resources. In error cases, we may still have buffers left to
-		// close. We do that here.
+		// free resources, setting the corresponding entries in profiles to nil.
+		// In error cases, we may still have buffers left to close. We do that
+		// here.
 		for _, prof := range profiles {
 			if prof == nil {
 				continue


### PR DESCRIPTION
Use temporary files to buffer profiles that we aggregate from other machines. The existing code buffers in memory, and some computations produce large profiles, e.g. large goroutine profiles. Instead, download the profiles into temporary files before merging them.