### PR TITLE
Bookkeep muxer correctly for local system Tail

### DIFF
--- a/local.go
+++ b/local.go
@@ -91,9 +91,6 @@ func (s *localSystem) Start(ctx context.Context, count int) ([]*Machine, error) 
 		cmd.Env = append(cmd.Env, "BIGMACHINE_MODE=machine")
 		cmd.Env = append(cmd.Env, "BIGMACHINE_SYSTEM=local")
 		muxer := new(tee.Writer)
-		s.mu.Lock()
-		s.muxers[machines[i]] = muxer
-		s.mu.Unlock()
 		cmd.Stdout = iofmt.PrefixWriter(muxer, prefix)
 		cmd.Stderr = iofmt.PrefixWriter(muxer, prefix)
 		cmd.Env = append(cmd.Env, fmt.Sprintf("BIGMACHINE_ADDR=:%d", port))
@@ -101,6 +98,9 @@ func (s *localSystem) Start(ctx context.Context, count int) ([]*Machine, error) 
 
 		m := new(Machine)
 		m.Addr = fmt.Sprintf("https://localhost:%d/", port)
+		s.mu.Lock()
+		s.muxers[m] = muxer
+		s.mu.Unlock()
 		m.Maxprocs = 1
 		err = cmd.Start()
 		if err != nil {


### PR DESCRIPTION
Bookkeep the muxer used to merge `Stdout` and `Stderr` from the machine process, which is used to tail logs from the machine. We construct a map keyed by machine pointer key, but we use a `nil` key. Fix to use the correct machine pointer.

`Tail` now works correctly, instead of showing the message, "machine not under management".