### PR TITLE
Use loopback address for local communication

### DIFF
--- a/ec2system/ec2machine_test.go
+++ b/ec2system/ec2machine_test.go
@@ -76,7 +76,7 @@ func TestMutualHTTPS(t *testing.T) {
 
 	var listenAndServeError errors.Once
 	go func() {
-		listenAndServeError.Set(sys.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), mux))
+		listenAndServeError.Set(sys.ListenAndServe(fmt.Sprintf("localhost:%d", port), mux))
 	}()
 	time.Sleep(time.Second)
 
@@ -84,7 +84,7 @@ func TestMutualHTTPS(t *testing.T) {
 	transport := &http.Transport{TLSClientConfig: config}
 	http2.ConfigureTransport(transport)
 	client := &http.Client{Transport: transport}
-	_, err = client.Get(fmt.Sprintf("https://127.0.0.1:%d/", port))
+	_, err = client.Get(fmt.Sprintf("https://localhost:%d/", port))
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -97,7 +97,7 @@ func TestMutualHTTPS(t *testing.T) {
 }
 
 func getFreeTCPPort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {
 		return 0, err
 	}

--- a/ec2system/ec2machine_test.go
+++ b/ec2system/ec2machine_test.go
@@ -76,7 +76,7 @@ func TestMutualHTTPS(t *testing.T) {
 
 	var listenAndServeError errors.Once
 	go func() {
-		listenAndServeError.Set(sys.ListenAndServe(fmt.Sprintf(":%d", port), mux))
+		listenAndServeError.Set(sys.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), mux))
 	}()
 	time.Sleep(time.Second)
 
@@ -84,7 +84,7 @@ func TestMutualHTTPS(t *testing.T) {
 	transport := &http.Transport{TLSClientConfig: config}
 	http2.ConfigureTransport(transport)
 	client := &http.Client{Transport: transport}
-	_, err = client.Get(fmt.Sprintf("https://localhost:%d/", port))
+	_, err = client.Get(fmt.Sprintf("https://127.0.0.1:%d/", port))
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -97,7 +97,7 @@ func TestMutualHTTPS(t *testing.T) {
 }
 
 func getFreeTCPPort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", ":0")
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0, err
 	}

--- a/local.go
+++ b/local.go
@@ -85,7 +85,7 @@ func (s *localSystem) Start(ctx context.Context, count int) ([]*Machine, error) 
 		if err != nil {
 			return nil, err
 		}
-		prefix := fmt.Sprintf("127.0.0.1:%d: ", port)
+		prefix := fmt.Sprintf("localhost:%d: ", port)
 		cmd := exec.Command(os.Args[0], os.Args[1:]...)
 		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, "BIGMACHINE_MODE=machine")
@@ -96,11 +96,11 @@ func (s *localSystem) Start(ctx context.Context, count int) ([]*Machine, error) 
 		s.mu.Unlock()
 		cmd.Stdout = iofmt.PrefixWriter(muxer, prefix)
 		cmd.Stderr = iofmt.PrefixWriter(muxer, prefix)
-		cmd.Env = append(cmd.Env, fmt.Sprintf("BIGMACHINE_ADDR=127.0.0.1:%d", port))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("BIGMACHINE_ADDR=localhost:%d", port))
 		cmd.Env = append(cmd.Env, fmt.Sprintf("BIGMACHINE_AUTHORITY=%s", s.authorityFilename))
 
 		m := new(Machine)
-		m.Addr = fmt.Sprintf("https://127.0.0.1:%d/", port)
+		m.Addr = fmt.Sprintf("https://localhost:%d/", port)
 		m.Maxprocs = 1
 		err = cmd.Start()
 		if err != nil {
@@ -219,7 +219,7 @@ func (s *localSystem) Read(ctx context.Context, m *Machine, filename string) (io
 }
 
 func getFreeTCPPort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {
 		return 0, err
 	}

--- a/local.go
+++ b/local.go
@@ -85,7 +85,7 @@ func (s *localSystem) Start(ctx context.Context, count int) ([]*Machine, error) 
 		if err != nil {
 			return nil, err
 		}
-		prefix := fmt.Sprintf("localhost:%d: ", port)
+		prefix := fmt.Sprintf("127.0.0.1:%d: ", port)
 		cmd := exec.Command(os.Args[0], os.Args[1:]...)
 		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, "BIGMACHINE_MODE=machine")
@@ -96,11 +96,11 @@ func (s *localSystem) Start(ctx context.Context, count int) ([]*Machine, error) 
 		s.mu.Unlock()
 		cmd.Stdout = iofmt.PrefixWriter(muxer, prefix)
 		cmd.Stderr = iofmt.PrefixWriter(muxer, prefix)
-		cmd.Env = append(cmd.Env, fmt.Sprintf("BIGMACHINE_ADDR=:%d", port))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("BIGMACHINE_ADDR=127.0.0.1:%d", port))
 		cmd.Env = append(cmd.Env, fmt.Sprintf("BIGMACHINE_AUTHORITY=%s", s.authorityFilename))
 
 		m := new(Machine)
-		m.Addr = fmt.Sprintf("https://localhost:%d/", port)
+		m.Addr = fmt.Sprintf("https://127.0.0.1:%d/", port)
 		m.Maxprocs = 1
 		err = cmd.Start()
 		if err != nil {
@@ -176,7 +176,6 @@ func (s *localSystem) HTTPClient() *http.Client {
 	http2.ConfigureTransport(transport)
 	return &http.Client{Transport: transport}
 }
-
 func (*localSystem) Exit(code int) {
 	os.Exit(code)
 }
@@ -220,7 +219,7 @@ func (s *localSystem) Read(ctx context.Context, m *Machine, filename string) (io
 }
 
 func getFreeTCPPort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", ":0")
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0, err
 	}

--- a/regress/tests/teststream.go
+++ b/regress/tests/teststream.go
@@ -31,7 +31,7 @@ type service struct{}
 
 func (service) Empty(ctx context.Context, howlong time.Duration, reply *io.ReadCloser) error {
 	http2.VerboseLogs = true
-	go http.ListenAndServe(":9090", nil)
+	go http.ListenAndServe("127.0.0.1:9090", nil)
 	*reply = ioutil.NopCloser(bytes.NewReader(nil))
 	return nil
 }

--- a/regress/tests/teststream.go
+++ b/regress/tests/teststream.go
@@ -31,7 +31,7 @@ type service struct{}
 
 func (service) Empty(ctx context.Context, howlong time.Duration, reply *io.ReadCloser) error {
 	http2.VerboseLogs = true
-	go http.ListenAndServe("127.0.0.1:9090", nil)
+	go http.ListenAndServe("localhost:9090", nil)
 	*reply = ioutil.NopCloser(bytes.NewReader(nil))
 	return nil
 }


### PR DESCRIPTION
Use loopback address for local communication to avoid exposing ports externally. This has the side effect of not triggering OS X dialogs prompting users to deny/allow access to incoming traffic, in tests and `Local` system usage.