### PR TITLE
Accept `func () io.Reader` argument for RPC

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -133,6 +133,12 @@ func (c *Client) getLogger(addr string) *rateLimitingOutputter {
 // an error occurs while the response is streamed, the returned
 // io.ReadCloser errors on read.
 //
+// If the argument is a function that returns an (func () io.Reader), the
+// function is called to make the reader streamed directly to the server method
+// as above. This is mostly useful when using Call in a retry loop, as you often
+// want to create a new reader for each call, as opposed to continuing from
+// whatever unknown state remains from previously attempted calls.
+//
 // Remote errors are decoded into *errors.Error and returned.
 // (Non-*errors.Error errors are converted by the server.) The RPC
 // client does not pass on errors of kind errors.Net; these are

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -133,11 +133,11 @@ func (c *Client) getLogger(addr string) *rateLimitingOutputter {
 // an error occurs while the response is streamed, the returned
 // io.ReadCloser errors on read.
 //
-// If the argument is a function that returns an (func () io.Reader), the
-// function is called to make the reader streamed directly to the server method
-// as above. This is mostly useful when using Call in a retry loop, as you often
-// want to create a new reader for each call, as opposed to continuing from
-// whatever unknown state remains from previously attempted calls.
+// If the argument is a (func () io.Reader), it is called to get a reader
+// streamed directly to the server method as above. This is mostly useful when
+// using Call in a retry loop, as you often want to create a new reader for each
+// call, as opposed to continuing from whatever unknown state remains from
+// previously attempted calls.
 //
 // Remote errors are decoded into *errors.Error and returned.
 // (Non-*errors.Error errors are converted by the server.) The RPC

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -165,6 +165,9 @@ func (c *Client) Call(ctx context.Context, addr, serviceMethod string, arg, repl
 		contentType string
 	)
 	switch arg := arg.(type) {
+	case func() io.Reader:
+		body = arg()
+		contentType = "application/octet-stream"
 	case io.Reader:
 		body = arg
 		contentType = "application/octet-stream"


### PR DESCRIPTION
`Call` and `RetryCall` can take an `io.Reader` as an argument. There is a subtle (to me) implication in the `RetryCall` case. If the call needs retrying, subsequent calls will just get whatever state of the `io.Reader` is left over from previous attempts. This can be problematic for some (many?) use cases.

Introduce the ability to pass a `func() io.Reader` which will be called for each `Call` to produce the reader for the argument.

This will be used to make [a recently added usage of an `io.Reader` argument in Bigslice](https://github.com/grailbio/bigslice/blob/2e7d373d6021eeed3bfc68803816bd4f6ee30daa/exec/bigmachine.go#L243-L244) more fault-tolerant.