### PR TITLE
Use in-memory PEM instead of re-reading from file

### DIFF
--- a/ec2system/ec2machine.go
+++ b/ec2system/ec2machine.go
@@ -231,8 +231,7 @@ type System struct {
 
 	ec2 ec2iface.EC2API
 
-	authority         *authority.T
-	authorityContents []byte
+	authority *authority.T
 
 	clientOnce   once.Task
 	clientConfig *tls.Config
@@ -335,10 +334,6 @@ func (s *System) Init(b *bigmachine.B) error {
 	}
 	s.ec2 = ec2.New(sess)
 	s.authority, err = authority.New(authorityPath)
-	if err != nil {
-		return err
-	}
-	s.authorityContents, err = ioutil.ReadFile(authorityPath)
 	if err != nil {
 		return err
 	}
@@ -833,7 +828,7 @@ func (s *System) cloudConfig() *cloudConfig {
 	c.AppendFile(CloudFile{
 		Permissions: "0644",
 		Path:        authorityPath,
-		Content:     string(s.authorityContents),
+		Content:     string(s.authority.Contents()),
 	})
 
 	sysctlPath := "/lib/systemd/systemd-sysctl"

--- a/internal/authority/authority.go
+++ b/internal/authority/authority.go
@@ -16,6 +16,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"math/big"
 	"net"
@@ -34,6 +35,10 @@ const certDuration = 7 * 24 * time.Hour
 //  A T is a TLS certificate authority which can issue client and server
 // certificates and provide configuration for HTTPS clients.
 type T struct {
+	// pem is the PEM-encoded bytes of the CA. The key and certificate are also
+	// stored in other forms for convenient access.
+	pem []byte
+
 	key  *rsa.PrivateKey
 	cert *x509.Certificate
 
@@ -50,7 +55,7 @@ type T struct {
 func New(filename string) (*T, error) {
 	// As an extra precaution, we always exercise the read path, so if
 	// the CA PEM is missing, we generate it, and then read it back.
-	pemBlock, err := cached(filename, func() ([]byte, error) {
+	caPem, err := cached(filename, func() ([]byte, error) {
 		key, err := rsa.GenerateKey(rand.Reader, 2048)
 		if err != nil {
 			return nil, err
@@ -82,8 +87,16 @@ func New(filename string) (*T, error) {
 		}
 		return b.Bytes(), nil
 	})
+	if err != nil {
+		return nil, fmt.Errorf("could not build CA: %v", err)
+	}
 
-	var certBlock, keyBlock []byte
+	var (
+		// pemBlock is updated to hold the remaining blocks in the CA as we
+		// decode them.
+		pemBlock            = caPem
+		certBlock, keyBlock []byte
+	)
 	for {
 		var derBlock *pem.Block
 		derBlock, pemBlock = pem.Decode(pemBlock)
@@ -102,6 +115,7 @@ func New(filename string) (*T, error) {
 		return nil, errors.New("httpsca: incomplete certificate")
 	}
 	ca := new(T)
+	ca.pem = caPem
 	ca.cert, err = x509.ParseCertificate(certBlock)
 	if err != nil {
 		return nil, err
@@ -119,6 +133,11 @@ func New(filename string) (*T, error) {
 		return nil, err
 	}
 	return ca, nil
+}
+
+// Contents returns the PEM-encoded contents of the authority.
+func (c *T) Contents() []byte {
+	return c.pem
 }
 
 // Cert returns the authority's x509 certificate.


### PR DESCRIPTION
Use in-memory PEM instead of re-reading PEM from file. This eliminates a race when multiple `bigmachine` programs are reading/writing to the cached authority, e.g.:

1. `A` sees no file at `/tmp/bigmachine.pem`.
2. `B` sees no file at `/tmp/bigmachine.pem`.
3. `A` generates a new authority and writes it to `/tmp/bigmachine.pem`.
4. `B` generates a new authority and writes it to `/tmp/bigmachine.pem`, overwriting `A`'s authority.
5. `A` re-reads the authority contents, which is then passed to machines.
6. `A` client certificate cannot be used to connect to the machines.