### PR TITLE
Add (System).Serve to simplify serving

### DIFF
--- a/ec2system/ec2machine.go
+++ b/ec2system/ec2machine.go
@@ -938,9 +938,15 @@ func (s *System) Event(typ string, fieldPairs ...interface{}) {
 	s.Eventer.Event(typ, fieldPairs...)
 }
 
-// ListenAndServe serves the provided handler on a HTTP server
-// configured for secure communications between ec2system
-// instances.
+func (s *System) Serve(l net.Listener, handler http.Handler) error {
+	server, err := s.newServer(handler)
+	if err != nil {
+		return err
+	}
+	server.Addr = l.Addr().String()
+	return server.ServeTLS(l, "", "")
+}
+
 func (s *System) ListenAndServe(addr string, handler http.Handler) error {
 	if addr == "" {
 		addr = os.Getenv("BIGMACHINE_ADDR")
@@ -948,33 +954,11 @@ func (s *System) ListenAndServe(addr string, handler http.Handler) error {
 	if addr == "" {
 		return errors.E(errors.Invalid, "no address defined")
 	}
-	_, config, err := s.authority.HTTPSConfig()
+	server, err := s.newServer(handler)
 	if err != nil {
 		return err
 	}
-	if useInstanceIDSuffix {
-		sess, err := session.NewSession(s.AWSConfig)
-		if err != nil {
-			log.Error.Printf("session.NewSession: %v", err)
-			return err
-		}
-		meta := ec2metadata.New(sess)
-		doc, err := meta.GetInstanceIdentityDocument()
-		if err != nil {
-			log.Error.Printf("ec2metadata.GetInstanceIdentityDocument: %v", err)
-			return err
-		}
-		handler = http.StripPrefix("/"+doc.InstanceID, handler)
-	}
-	config.ClientAuth = tls.RequireAndVerifyClientCert
-	server := &http.Server{
-		TLSConfig: config,
-		Addr:      addr,
-		Handler:   handler,
-	}
-	http2.ConfigureServer(server, &http2.Server{
-		MaxConcurrentStreams: maxConcurrentStreams,
-	})
+	server.Addr = addr
 	return server.ListenAndServeTLS("", "")
 }
 
@@ -998,6 +982,36 @@ func (s *System) Read(ctx context.Context, m *bigmachine.Machine, filename strin
 		return nil, err
 	}
 	return s.run(ctx, u.Hostname(), "cat "+filename), nil
+}
+
+func (s *System) newServer(handler http.Handler) (*http.Server, error) {
+	_, config, err := s.authority.HTTPSConfig()
+	if err != nil {
+		return nil, err
+	}
+	if useInstanceIDSuffix {
+		sess, err := session.NewSession(s.AWSConfig)
+		if err != nil {
+			log.Error.Printf("session.NewSession: %v", err)
+			return nil, err
+		}
+		meta := ec2metadata.New(sess)
+		doc, err := meta.GetInstanceIdentityDocument()
+		if err != nil {
+			log.Error.Printf("ec2metadata.GetInstanceIdentityDocument: %v", err)
+			return nil, err
+		}
+		handler = http.StripPrefix("/"+doc.InstanceID, handler)
+	}
+	config.ClientAuth = tls.RequireAndVerifyClientCert
+	server := &http.Server{
+		TLSConfig: config,
+		Handler:   handler,
+	}
+	http2.ConfigureServer(server, &http2.Server{
+		MaxConcurrentStreams: maxConcurrentStreams,
+	})
+	return server, nil
 }
 
 func (s *System) dialSSH(addr string) (*ssh.Client, error) {

--- a/ec2system/ec2machine_test.go
+++ b/ec2system/ec2machine_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/grailbio/base/errors"
 	"github.com/grailbio/bigmachine/internal/authority"
@@ -54,14 +53,10 @@ func TestMutualHTTPS(t *testing.T) {
 		fmt.Fprintln(w, "ok")
 	})
 
-	port, err := getFreeTCPPort()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	temp, cleanup := testutil.TempDir(t, "", "")
 	defer cleanup()
 
+	var err error
 	sys := new(System)
 	sys.authority, err = authority.New(filepath.Join(temp, "authority"))
 	if err != nil {
@@ -74,17 +69,20 @@ func TestMutualHTTPS(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
 	var listenAndServeError errors.Once
 	go func() {
-		listenAndServeError.Set(sys.ListenAndServe(fmt.Sprintf("localhost:%d", port), mux))
+		listenAndServeError.Set(sys.Serve(l, mux))
 	}()
-	time.Sleep(time.Second)
 
 	config, _, err := authority.HTTPSConfig()
 	transport := &http.Transport{TLSClientConfig: config}
 	http2.ConfigureTransport(transport)
 	client := &http.Client{Transport: transport}
-	_, err = client.Get(fmt.Sprintf("https://localhost:%d/", port))
+	_, err = client.Get(fmt.Sprintf("https://%s/", l.Addr().String()))
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -94,18 +92,4 @@ func TestMutualHTTPS(t *testing.T) {
 	if err := listenAndServeError.Err(); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func getFreeTCPPort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	if err != nil {
-		return 0, err
-	}
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return 0, err
-	}
-	port := l.Addr().(*net.TCPAddr).Port
-	l.Close()
-	return port, nil
 }

--- a/system.go
+++ b/system.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/gob"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"sync"
@@ -43,6 +44,9 @@ type System interface {
 	// HTTPClient returns an HTTP client that can be used to communicate
 	// from drivers to machines as well as between machines.
 	HTTPClient() *http.Client
+	// Serve serves the provided handler on an HTTP server listening on Listener
+	// l that is reachable from other instances in the bigmachine cluster.
+	Serve(l net.Listener, handle http.Handler) error
 	// ListenAndServe serves the provided handler on an HTTP server that
 	// is reachable from other instances in the bigmachine cluster. If addr
 	// is the empty string, the default cluster address is used.

--- a/testsystem/testsystem.go
+++ b/testsystem/testsystem.go
@@ -13,6 +13,7 @@ import (
 	"encoding/gob"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -172,6 +173,12 @@ func (*System) Event(_ string, _ ...interface{}) {}
 // servers created by this test system.
 func (s *System) HTTPClient() *http.Client {
 	return s.client
+}
+
+// Serve panics. It should not be called, provided a
+// correct bigmachine implementation.
+func (s *System) Serve(l net.Listener, handler http.Handler) error {
+	panic("Serve called on testsystem")
 }
 
 // ListenAndServe panics. It should not be called, provided a


### PR DESCRIPTION
Add a `(System).Serve` interface method to allow serving on a given listener. This allows us to get rid of the `getFreeTCPPort` method and mirrors the `http.Listen` and `http.ListenAndServe` methods.

I did this while I was trying to fix a non-deterministically failing test, and I think it makes the code a bit easier to understand, as it eliminates the somewhat odd listen-then-close thing that `getFreeTCPPort` did.