### PR TITLE
Migrate from CoreOS to Flatcar

### DIFF
--- a/ec2system/config.go
+++ b/ec2system/config.go
@@ -27,7 +27,8 @@ func init() {
 		// TODO(marius): maybe defer defaults to system impl?
 		constr.BoolVar(&system.OnDemand, "ondemand", false, "use on-demand instances")
 		constr.StringVar(&system.InstanceType, "instance", "m3.medium", "instance type to allocate")
-		constr.StringVar(&system.AMI, "ami", "ami-4296ec3a", "AMI to bootstrap")
+		// Flatcar-stable-2512.2.1-hvm
+		constr.StringVar(&system.AMI, "ami", "ami-0bb54692374ac10a7", "AMI to bootstrap")
 		constr.StringVar(&system.InstanceProfile, "instance-profile", "",
 			"the instance profile with which to launch new instances")
 		constr.StringVar(&system.SecurityGroup, "security-group", "",

--- a/ec2system/ec2machine.go
+++ b/ec2system/ec2machine.go
@@ -269,7 +269,7 @@ func (s *System) Init(b *bigmachine.B) error {
 	}
 	// TODO(marius): derive defaults from a config
 	if s.AMI == "" {
-		s.AMI = "ami-4296ec3a"
+		s.AMI = "ami-0bb54692374ac10a7"
 	}
 	if s.AWSConfig == nil {
 		s.AWSConfig = &aws.Config{}


### PR DESCRIPTION
CoreOS has reached [the end of its life ](https://coreos.com/os/eol/). Flatcar is a [drop-in replacement](https://www.flatcar-linux.org/).

Flatcar documentation says that `cloud-init`, which Bigmachine uses, [is deprecated](https://docs.flatcar-linux.org/os/provisioning/#migrating-from-cloud-configs). However, the developers say that ["`cloud-config` will continue to work ... for the foreseeable future."](https://groups.google.com/g/flatcar-linux-user/c/DTjvoOwZlIk).