### PR TITLE
Tolerate describe-images errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Check out
       uses: actions/checkout@v2
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.27
+        version: v1.29
         only-new-issues: true

--- a/ec2system/ec2machine.go
+++ b/ec2system/ec2machine.go
@@ -382,13 +382,13 @@ func (s *System) Start(ctx context.Context, count int) ([]*bigmachine.Machine, e
 			return err2
 		}
 		if len(out.Images) != 1 || aws.StringValue(out.Images[0].ImageId) != s.AMI {
-			return errors.New("image not found")
+			return errors.E(errors.Fatal, "image not found")
 		}
 		imageInfo.Store(s.AMI, out.Images[0])
 		return nil
 	})
 	if err != nil {
-		if err == ctx.Err() {
+		if e, ok := err.(*errors.Error); ok && e.Severity != errors.Fatal {
 			describeImages.Forget(s.AMI)
 		}
 		return nil, errors.E("describe-images", s.AMI, err)


### PR DESCRIPTION
Tolerate more `describe-images` errors, retrying when we attempt to start more machines. `describe-images` can fail for reasons like `RequestLimitExceeded`, which are okay to retry (even after the SDK has already retried). Instead of memoizing these failures, forget them, and allow future attempts to start machines to try the call again.