### PR TITLE
Upgrade to golangci-lint-action@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Check out
       uses: actions/checkout@v2
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.27
+        version: v1.29
         only-new-issues: true


### PR DESCRIPTION
This also upgrades us to golangci-lint v1.29.