### PR TITLE
Fail fast when service cannot be gob-encoded

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -206,9 +206,10 @@ func TestBadServiceFastFail(t *testing.T) {
 	m, _, shutdown := newTestMachine(t, Services{"GobUnregistered": gobUnregisteredService{}})
 	defer shutdown()
 	select {
-	case <-m.Wait(Stopped):
 	case <-m.Wait(Running):
-		t.Fatalf("machine is running with broken service")
+		if m.State() == Running {
+			t.Fatalf("machine is running with broken service")
+		}
 	case <-time.After(2 * time.Minute):
 		// If our test environment causes this to falsely fail, we almost
 		// surely have lots of other problems, as this should otherwise fail

--- a/machine_test.go
+++ b/machine_test.go
@@ -197,7 +197,7 @@ func TestMachineContext(t *testing.T) {
 }
 
 // gobUnregisteredService is a service that is not registered with gob, so
-// attempts to register it will fail.
+// attempts to register it with bigmachine will fail.
 type gobUnregisteredService struct{}
 
 // TestBadServiceFastFail verifies that we fail fast when a service is not


### PR DESCRIPTION
Fail fast when service cannot be gob-encoded. In general, we should fail fast if service registration fails fatally. The current behavior is that we will retry for several minutes.