### PR TITLE
Fail fast on (service).Init panic

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -257,7 +257,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if e := recover(); e != nil {
 				log.Error.Printf("panic in method call %s.%s\n%s", service, method, string(debug.Stack()))
-				err = fmt.Errorf("panic: %v", e)
+				err = errors.E(errors.Fatal, fmt.Errorf("panic: %v", e))
 			}
 		}()
 		rvs := m.method.Func.Call([]reflect.Value{svc.recv, reflect.ValueOf(ctx), argv, replyv})


### PR DESCRIPTION
Fail fast when `(service).Init` panics. We make the assumption that a panic in `Init` is unrecoverable, so we fail fast, so it's faster (fails faster) and easier (less log noise) to recognize.

Note that we're taking a conservative approach. If `Init` merely returns a non-fatal error, we will still retry.